### PR TITLE
add: Support for std::ops::Not for FheUint8

### DIFF
--- a/src/shortint/mod.rs
+++ b/src/shortint/mod.rs
@@ -1,4 +1,4 @@
-mod enc_dec;
+pub(crate) mod enc_dec;
 mod ops;
 
 pub type FheUint8 = enc_dec::FheUint8<Vec<u64>>;
@@ -288,6 +288,23 @@ mod frontend {
             pub fn min(&self, other: &FheUint8) -> FheUint8 {
                 let self_lt = self.lt(other);
                 self.mux(other, &self_lt)
+            }
+        }
+
+        impl std::ops::Not for &FheUint8 {
+            type Output = FheUint8;
+            fn not(self) -> Self::Output {
+                BoolEvaluator::with_local(|e| FheUint8 {
+                    data: self.data().iter().map(|b| e.not(b)).collect(),
+                })
+            }
+        }
+
+        impl std::ops::Not for FheUint8 {
+            type Output = FheUint8;
+            fn not(self) -> Self::Output {
+                // This just calls the impl above with 0 overhead.
+                !(&self)
             }
         }
     }


### PR DESCRIPTION
This PR adds support for the `std::ops::Not` operator for `FheUint8` such that we can use the `!` operator within a PhantomZone circuit.