### PR TITLE
Rename Non-Native to Foreign

### DIFF
--- a/crypto/benches/rlwe.rs
+++ b/crypto/benches/rlwe.rs
@@ -5,8 +5,8 @@ use phantom_zone_crypto::core::{
 };
 use phantom_zone_math::{
     decomposer::DecompositionParam,
-    modulus::{Modulus, NonNativePowerOfTwo, Prime},
-    ring::{NoisyNativeRing, NoisyNonNativePowerOfTwoRing, NoisyPrimeRing, PrimeRing, RingOps},
+    modulus::{Modulus, ForeignPowerOfTwo, Prime},
+    ring::{NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing, PrimeRing, RingOps},
 };
 
 fn automorphism(c: &mut Criterion) {
@@ -38,9 +38,9 @@ fn automorphism(c: &mut Criterion) {
                 let modulus = Modulus::native();
                 runner::<NoisyNativeRing>(modulus, ring_size, decomposition_param)
             }),
-            ("noisy_non_native_power_of_two", {
-                let modulus = NonNativePowerOfTwo::new(54).into();
-                runner::<NoisyNonNativePowerOfTwoRing>(modulus, ring_size, decomposition_param)
+            ("noisy_foreign_power_of_two", {
+                let modulus = ForeignPowerOfTwo::new(54).into();
+                runner::<NoisyForeignPowerOfTwoRing>(modulus, ring_size, decomposition_param)
             }),
             ("noisy_prime", {
                 let modulus = Prime::gen(54, log_ring_size + 1).into();
@@ -96,9 +96,9 @@ fn rlwe_by_rgsw(c: &mut Criterion) {
                 let modulus = Modulus::native();
                 runner::<NoisyNativeRing>(modulus, ring_size, decomposition_param)
             }),
-            ("noisy_non_native_power_of_two", {
-                let modulus = NonNativePowerOfTwo::new(54).into();
-                runner::<NoisyNonNativePowerOfTwoRing>(modulus, ring_size, decomposition_param)
+            ("noisy_foreign_power_of_two", {
+                let modulus = ForeignPowerOfTwo::new(54).into();
+                runner::<NoisyForeignPowerOfTwoRing>(modulus, ring_size, decomposition_param)
             }),
             ("noisy_prime", {
                 let modulus = Prime::gen(54, log_ring_size + 1).into();

--- a/crypto/benches/rlwe.rs
+++ b/crypto/benches/rlwe.rs
@@ -5,8 +5,8 @@ use phantom_zone_crypto::core::{
 };
 use phantom_zone_math::{
     decomposer::DecompositionParam,
-    modulus::{Modulus, ForeignPowerOfTwo, Prime},
-    ring::{NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing, PrimeRing, RingOps},
+    modulus::{ForeignPowerOfTwo, Modulus, Prime},
+    ring::{NoisyForeignPowerOfTwoRing, NoisyNativeRing, NoisyPrimeRing, PrimeRing, RingOps},
 };
 
 fn automorphism(c: &mut Criterion) {

--- a/crypto/src/core/lwe/test.rs
+++ b/crypto/src/core/lwe/test.rs
@@ -11,10 +11,10 @@ use crate::{
 use phantom_zone_math::{
     decomposer::DecompositionParam,
     distribution::Gaussian,
-    modulus::{Modulus, ForeignPowerOfTwo, Prime},
+    modulus::{ForeignPowerOfTwo, Modulus, Prime},
     ring::{
-        NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
-        ForeignPowerOfTwoRing, PrimeRing, RingOps,
+        ForeignPowerOfTwoRing, NativeRing, NoisyForeignPowerOfTwoRing, NoisyNativeRing,
+        NoisyPrimeRing, PrimeRing, RingOps,
     },
 };
 use rand::{thread_rng, RngCore};

--- a/crypto/src/core/lwe/test.rs
+++ b/crypto/src/core/lwe/test.rs
@@ -11,10 +11,10 @@ use crate::{
 use phantom_zone_math::{
     decomposer::DecompositionParam,
     distribution::Gaussian,
-    modulus::{Modulus, NonNativePowerOfTwo, Prime},
+    modulus::{Modulus, ForeignPowerOfTwo, Prime},
     ring::{
-        NativeRing, NoisyNativeRing, NoisyNonNativePowerOfTwoRing, NoisyPrimeRing,
-        NonNativePowerOfTwoRing, PrimeRing, RingOps,
+        NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
+        ForeignPowerOfTwoRing, PrimeRing, RingOps,
     },
 };
 use rand::{thread_rng, RngCore};
@@ -175,9 +175,9 @@ fn encrypt_decrypt() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 0)));
     run::<PrimeRing>(test_param(Prime::gen(50, 0)));
 }
@@ -200,9 +200,9 @@ fn key_switch() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 0)));
     run::<PrimeRing>(test_param(Prime::gen(50, 0)));
 }

--- a/crypto/src/core/rgsw/test.rs
+++ b/crypto/src/core/rgsw/test.rs
@@ -14,10 +14,10 @@ use phantom_zone_math::{
     decomposer::Decomposer,
     distribution::Sampler,
     izip_eq,
-    modulus::{ElemFrom, Modulus, ForeignPowerOfTwo, Prime},
+    modulus::{ElemFrom, ForeignPowerOfTwo, Modulus, Prime},
     ring::{
-        NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
-        ForeignPowerOfTwoRing, PrimeRing, RingOps,
+        ForeignPowerOfTwoRing, NativeRing, NoisyForeignPowerOfTwoRing, NoisyNativeRing,
+        NoisyPrimeRing, PrimeRing, RingOps,
     },
 };
 use rand::RngCore;

--- a/crypto/src/core/rgsw/test.rs
+++ b/crypto/src/core/rgsw/test.rs
@@ -14,10 +14,10 @@ use phantom_zone_math::{
     decomposer::Decomposer,
     distribution::Sampler,
     izip_eq,
-    modulus::{ElemFrom, Modulus, NonNativePowerOfTwo, Prime},
+    modulus::{ElemFrom, Modulus, ForeignPowerOfTwo, Prime},
     ring::{
-        NativeRing, NoisyNativeRing, NoisyNonNativePowerOfTwoRing, NoisyPrimeRing,
-        NonNativePowerOfTwoRing, PrimeRing, RingOps,
+        NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
+        ForeignPowerOfTwoRing, PrimeRing, RingOps,
     },
 };
 use rand::RngCore;
@@ -64,7 +64,7 @@ impl<R: RingOps> Rgsw<R> {
         self.ring().ring_size()
     }
 
-    pub fn message_ring(&self) -> &NonNativePowerOfTwoRing {
+    pub fn message_ring(&self) -> &ForeignPowerOfTwoRing {
         self.rlwe.message_ring()
     }
 
@@ -213,9 +213,9 @@ fn rlwe_by_rgsw() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 9)));
     run::<PrimeRing>(test_param(Prime::gen(50, 9)));
 }
@@ -239,9 +239,9 @@ fn rgsw_by_rgsw() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 9)));
     run::<PrimeRing>(test_param(Prime::gen(50, 9)));
 }

--- a/crypto/src/core/rlwe/test.rs
+++ b/crypto/src/core/rlwe/test.rs
@@ -16,10 +16,10 @@ use itertools::Itertools;
 use phantom_zone_math::{
     decomposer::DecompositionParam,
     distribution::{Gaussian, Sampler, Ternary},
-    modulus::{Modulus, ModulusOps, ForeignPowerOfTwo, Prime},
+    modulus::{ForeignPowerOfTwo, Modulus, ModulusOps, Prime},
     ring::{
-        NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
-        ForeignPowerOfTwoRing, PrimeRing, RingOps, SliceOps,
+        ForeignPowerOfTwoRing, NativeRing, NoisyForeignPowerOfTwoRing, NoisyNativeRing,
+        NoisyPrimeRing, PrimeRing, RingOps, SliceOps,
     },
 };
 use rand::{thread_rng, RngCore};

--- a/crypto/src/core/rlwe/test.rs
+++ b/crypto/src/core/rlwe/test.rs
@@ -16,10 +16,10 @@ use itertools::Itertools;
 use phantom_zone_math::{
     decomposer::DecompositionParam,
     distribution::{Gaussian, Sampler, Ternary},
-    modulus::{Modulus, ModulusOps, NonNativePowerOfTwo, Prime},
+    modulus::{Modulus, ModulusOps, ForeignPowerOfTwo, Prime},
     ring::{
-        NativeRing, NoisyNativeRing, NoisyNonNativePowerOfTwoRing, NoisyPrimeRing,
-        NonNativePowerOfTwoRing, PrimeRing, RingOps, SliceOps,
+        NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
+        ForeignPowerOfTwoRing, PrimeRing, RingOps, SliceOps,
     },
 };
 use rand::{thread_rng, RngCore};
@@ -49,8 +49,8 @@ impl RlweParam {
 
     pub fn build<R: RingOps>(self) -> Rlwe<R> {
         let ring = R::new(self.ciphertext_modulus, self.ring_size);
-        let message_ring = NonNativePowerOfTwoRing::new(
-            NonNativePowerOfTwo::new(self.message_modulus.ilog2() as _).into(),
+        let message_ring = ForeignPowerOfTwoRing::new(
+            ForeignPowerOfTwo::new(self.message_modulus.ilog2() as _).into(),
             self.ring_size,
         );
         Rlwe {
@@ -65,7 +65,7 @@ impl RlweParam {
 pub struct Rlwe<R: RingOps> {
     param: RlweParam,
     ring: R,
-    message_ring: NonNativePowerOfTwoRing,
+    message_ring: ForeignPowerOfTwoRing,
 }
 
 impl<R: RingOps> Rlwe<R> {
@@ -77,7 +77,7 @@ impl<R: RingOps> Rlwe<R> {
         self.ring().ring_size()
     }
 
-    pub fn message_ring(&self) -> &NonNativePowerOfTwoRing {
+    pub fn message_ring(&self) -> &ForeignPowerOfTwoRing {
         &self.message_ring
     }
 
@@ -345,9 +345,9 @@ fn encrypt_decrypt() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 9)));
     run::<PrimeRing>(test_param(Prime::gen(50, 9)));
 }
@@ -368,9 +368,9 @@ fn sample_extract() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 9)));
     run::<PrimeRing>(test_param(Prime::gen(50, 9)));
 }
@@ -396,9 +396,9 @@ fn key_switch() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 9)));
     run::<PrimeRing>(test_param(Prime::gen(50, 9)));
 }
@@ -426,9 +426,9 @@ fn automorphism() {
     }
 
     run::<NoisyNativeRing>(test_param(Modulus::native()));
-    run::<NoisyNonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<NoisyForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NativeRing>(test_param(Modulus::native()));
-    run::<NonNativePowerOfTwoRing>(test_param(NonNativePowerOfTwo::new(50)));
+    run::<ForeignPowerOfTwoRing>(test_param(ForeignPowerOfTwo::new(50)));
     run::<NoisyPrimeRing>(test_param(Prime::gen(50, 9)));
     run::<PrimeRing>(test_param(Prime::gen(50, 9)));
 }

--- a/crypto/src/scheme/blind_rotation/lmkcdey.rs
+++ b/crypto/src/scheme/blind_rotation/lmkcdey.rs
@@ -7,8 +7,8 @@ use core::{cmp::Reverse, iter::successors};
 use itertools::{izip, Itertools};
 use phantom_zone_math::{
     izip_eq,
-    modulus::{ModulusOps, NonNativePowerOfTwo},
-    ring::{NonNativePowerOfTwoRing, RingOps},
+    modulus::{ModulusOps, ForeignPowerOfTwo},
+    ring::{ForeignPowerOfTwoRing, RingOps},
     util::scratch::Scratch,
 };
 
@@ -26,7 +26,7 @@ pub fn bootstrap<'a, 'b, 'c, R1: RingOps, R2: RingOps>(
 ) {
     debug_assert_eq!((2 * ring.ring_size()) % q, 0);
     let embedding_factor = 2 * ring.ring_size() / q;
-    let mod_q = NonNativePowerOfTwoRing::new(NonNativePowerOfTwo::new(q.ilog2() as _).into(), 1);
+    let mod_q = ForeignPowerOfTwoRing::new(ForeignPowerOfTwo::new(q.ilog2() as _).into(), 1);
     let (ct, ks_key, f_auto_neg_g) = (ct.into(), ks_key.into(), f_auto_neg_g.into());
 
     let mut ct_mod_switch = LweCiphertext::scratch(ks_key.from_dimension(), &mut scratch);
@@ -158,11 +158,11 @@ mod test {
     use phantom_zone_math::{
         decomposer::DecompositionParam,
         distribution::{Gaussian, Ternary},
-        modulus::{Modulus, NonNativePowerOfTwo, Prime},
+        modulus::{Modulus, ForeignPowerOfTwo, Prime},
         poly::automorphism::AutomorphismMap,
         ring::{
-            NativeRing, NoisyNativeRing, NoisyNonNativePowerOfTwoRing, NoisyPrimeRing,
-            NonNativePowerOfTwoRing, PrimeRing, RingOps,
+            NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
+            ForeignPowerOfTwoRing, PrimeRing, RingOps,
         },
         util::scratch::ScratchOwned,
     };
@@ -177,7 +177,7 @@ mod test {
     }
 
     impl BootstrappingParam {
-        fn build<R: RingOps>(self) -> (Rgsw<R>, Lwe<R>, Lwe<NonNativePowerOfTwoRing>) {
+        fn build<R: RingOps>(self) -> (Rgsw<R>, Lwe<R>, Lwe<ForeignPowerOfTwoRing>) {
             (
                 self.rgsw.build(),
                 self.rgsw.rlwe.to_lwe().build(),
@@ -209,7 +209,7 @@ mod test {
             },
             lwe_ks: LweParam {
                 message_modulus,
-                ciphertext_modulus: NonNativePowerOfTwo::new(16).into(),
+                ciphertext_modulus: ForeignPowerOfTwo::new(16).into(),
                 dimension: 100,
                 sk_distribution: Gaussian::new(3.2).into(),
                 noise_distribution: Gaussian::new(3.2).into(),
@@ -300,9 +300,9 @@ mod test {
 
         for embedding_factor in [1, 2] {
             run::<NoisyNativeRing>(Modulus::native(), embedding_factor);
-            run::<NoisyNonNativePowerOfTwoRing>(NonNativePowerOfTwo::new(50), embedding_factor);
+            run::<NoisyForeignPowerOfTwoRing>(ForeignPowerOfTwo::new(50), embedding_factor);
             run::<NativeRing>(Modulus::native(), embedding_factor);
-            run::<NonNativePowerOfTwoRing>(NonNativePowerOfTwo::new(50), embedding_factor);
+            run::<ForeignPowerOfTwoRing>(ForeignPowerOfTwo::new(50), embedding_factor);
             run::<NoisyPrimeRing>(Prime::gen(50, 12), embedding_factor);
             run::<PrimeRing>(Prime::gen(50, 12), embedding_factor);
         }

--- a/crypto/src/scheme/blind_rotation/lmkcdey.rs
+++ b/crypto/src/scheme/blind_rotation/lmkcdey.rs
@@ -7,7 +7,7 @@ use core::{cmp::Reverse, iter::successors};
 use itertools::{izip, Itertools};
 use phantom_zone_math::{
     izip_eq,
-    modulus::{ModulusOps, ForeignPowerOfTwo},
+    modulus::{ForeignPowerOfTwo, ModulusOps},
     ring::{ForeignPowerOfTwoRing, RingOps},
     util::scratch::Scratch,
 };
@@ -158,11 +158,11 @@ mod test {
     use phantom_zone_math::{
         decomposer::DecompositionParam,
         distribution::{Gaussian, Ternary},
-        modulus::{Modulus, ForeignPowerOfTwo, Prime},
+        modulus::{ForeignPowerOfTwo, Modulus, Prime},
         poly::automorphism::AutomorphismMap,
         ring::{
-            NativeRing, NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing,
-            ForeignPowerOfTwoRing, PrimeRing, RingOps,
+            ForeignPowerOfTwoRing, NativeRing, NoisyForeignPowerOfTwoRing, NoisyNativeRing,
+            NoisyPrimeRing, PrimeRing, RingOps,
         },
         util::scratch::ScratchOwned,
     };

--- a/math/benches/poly_mul.rs
+++ b/math/benches/poly_mul.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use phantom_zone_math::{
-    modulus::{Modulus, ForeignPowerOfTwo, Prime},
-    ring::{NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing, PrimeRing, RingOps},
+    modulus::{ForeignPowerOfTwo, Modulus, Prime},
+    ring::{NoisyForeignPowerOfTwoRing, NoisyNativeRing, NoisyPrimeRing, PrimeRing, RingOps},
 };
 
 fn poly_mul(c: &mut Criterion) {

--- a/math/benches/poly_mul.rs
+++ b/math/benches/poly_mul.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use phantom_zone_math::{
-    modulus::{Modulus, NonNativePowerOfTwo, Prime},
-    ring::{NoisyNativeRing, NoisyNonNativePowerOfTwoRing, NoisyPrimeRing, PrimeRing, RingOps},
+    modulus::{Modulus, ForeignPowerOfTwo, Prime},
+    ring::{NoisyNativeRing, NoisyForeignPowerOfTwoRing, NoisyPrimeRing, PrimeRing, RingOps},
 };
 
 fn poly_mul(c: &mut Criterion) {
@@ -22,9 +22,9 @@ fn poly_mul(c: &mut Criterion) {
                 let modulus = Modulus::native();
                 runner(NoisyNativeRing::new(modulus, ring_size))
             }),
-            ("noisy_non_native_power_of_two", {
-                let modulus = NonNativePowerOfTwo::new(50).into();
-                runner(NoisyNonNativePowerOfTwoRing::new(modulus, ring_size))
+            ("noisy_foreign_power_of_two", {
+                let modulus = ForeignPowerOfTwo::new(50).into();
+                runner(NoisyForeignPowerOfTwoRing::new(modulus, ring_size))
             }),
             ("noisy_prime", {
                 let modulus = Prime::gen(50, log_ring_size + 1).into();

--- a/math/src/decomposer.rs
+++ b/math/src/decomposer.rs
@@ -243,10 +243,10 @@ impl Decomposer<u64> for PrimeDecomposer {
 mod test {
     use crate::{
         decomposer::{
-            Decomposer, DecompositionParam, NativeDecomposer, ForeignPowerOfTwoDecomposer,
+            Decomposer, DecompositionParam, ForeignPowerOfTwoDecomposer, NativeDecomposer,
             PrimeDecomposer,
         },
-        modulus::{Modulus, Native, ForeignPowerOfTwo, Prime},
+        modulus::{ForeignPowerOfTwo, Modulus, Native, Prime},
     };
     use core::iter::Sum;
     use num_traits::{Signed, ToPrimitive};

--- a/math/src/decomposer.rs
+++ b/math/src/decomposer.rs
@@ -76,7 +76,7 @@ pub trait Decomposer<T: 'static + Copy + Debug> {
 
 pub type NativeDecomposer = PowerOfTwoDecomposer<true>;
 
-pub type NonNativePowerOfTwoDecomposer = PowerOfTwoDecomposer<false>;
+pub type ForeignPowerOfTwoDecomposer = PowerOfTwoDecomposer<false>;
 
 #[derive(Clone, Copy, Debug)]
 pub struct PowerOfTwoDecomposer<const NATIVE: bool> {
@@ -243,10 +243,10 @@ impl Decomposer<u64> for PrimeDecomposer {
 mod test {
     use crate::{
         decomposer::{
-            Decomposer, DecompositionParam, NativeDecomposer, NonNativePowerOfTwoDecomposer,
+            Decomposer, DecompositionParam, NativeDecomposer, ForeignPowerOfTwoDecomposer,
             PrimeDecomposer,
         },
-        modulus::{Modulus, Native, NonNativePowerOfTwo, Prime},
+        modulus::{Modulus, Native, ForeignPowerOfTwo, Prime},
     };
     use core::iter::Sum;
     use num_traits::{Signed, ToPrimitive};
@@ -354,10 +354,10 @@ mod test {
         }
 
         run_po2::<NativeDecomposer>(Native::native());
-        run_po2::<NonNativePowerOfTwoDecomposer>(NonNativePowerOfTwo::new(50));
+        run_po2::<ForeignPowerOfTwoDecomposer>(ForeignPowerOfTwo::new(50));
 
         run_common::<NativeDecomposer>(Native::native());
-        run_common::<NonNativePowerOfTwoDecomposer>(NonNativePowerOfTwo::new(50));
+        run_common::<ForeignPowerOfTwoDecomposer>(ForeignPowerOfTwo::new(50));
         run_common::<PrimeDecomposer>(Prime::gen(50, 0));
     }
 
@@ -392,7 +392,7 @@ mod test {
         }
 
         run::<NativeDecomposer>(Native::native());
-        run::<NonNativePowerOfTwoDecomposer>(NonNativePowerOfTwo::new(50));
+        run::<ForeignPowerOfTwoDecomposer>(ForeignPowerOfTwo::new(50));
         run::<PrimeDecomposer>(Prime::gen(50, 0));
     }
 }

--- a/math/src/modulus.rs
+++ b/math/src/modulus.rs
@@ -5,13 +5,13 @@ use rand_distr::Distribution;
 pub(crate) mod power_of_two;
 pub(crate) mod prime;
 
-pub use power_of_two::{Native, NonNativePowerOfTwo};
+pub use power_of_two::{Native, ForeignPowerOfTwo};
 pub use prime::Prime;
 
 #[derive(Clone, Copy, Debug)]
 pub enum Modulus {
     Native(Native),
-    NonNativePowerOfTwo(NonNativePowerOfTwo),
+    ForeignPowerOfTwo(ForeignPowerOfTwo),
     Prime(Prime),
 }
 
@@ -23,7 +23,7 @@ impl Modulus {
     pub fn bits(&self) -> usize {
         match self {
             Self::Native(inner) => inner.bits(),
-            Self::NonNativePowerOfTwo(inner) => inner.bits(),
+            Self::ForeignPowerOfTwo(inner) => inner.bits(),
             Self::Prime(inner) => inner.bits(),
         }
     }
@@ -31,7 +31,7 @@ impl Modulus {
     pub fn max(&self) -> u64 {
         match self {
             Self::Native(inner) => inner.max(),
-            Self::NonNativePowerOfTwo(inner) => inner.max(),
+            Self::ForeignPowerOfTwo(inner) => inner.max(),
             Self::Prime(inner) => inner.max(),
         }
     }
@@ -39,7 +39,7 @@ impl Modulus {
     pub fn as_f64(&self) -> f64 {
         match self {
             Self::Native(inner) => inner.as_f64(),
-            Self::NonNativePowerOfTwo(inner) => inner.as_f64(),
+            Self::ForeignPowerOfTwo(inner) => inner.as_f64(),
             Self::Prime(inner) => inner.as_f64(),
         }
     }
@@ -47,7 +47,7 @@ impl Modulus {
     pub fn to_i64(&self, v: u64) -> i64 {
         match self {
             Self::Native(inner) => inner.to_i64(v),
-            Self::NonNativePowerOfTwo(inner) => inner.to_i64(v),
+            Self::ForeignPowerOfTwo(inner) => inner.to_i64(v),
             Self::Prime(inner) => inner.to_i64(v),
         }
     }

--- a/math/src/modulus.rs
+++ b/math/src/modulus.rs
@@ -5,7 +5,7 @@ use rand_distr::Distribution;
 pub(crate) mod power_of_two;
 pub(crate) mod prime;
 
-pub use power_of_two::{Native, ForeignPowerOfTwo};
+pub use power_of_two::{ForeignPowerOfTwo, Native};
 pub use prime::Prime;
 
 #[derive(Clone, Copy, Debug)]

--- a/math/src/modulus/power_of_two.rs
+++ b/math/src/modulus/power_of_two.rs
@@ -5,7 +5,7 @@ use crate::{
 use rand::distributions::{Distribution, Uniform};
 
 pub type Native = PowerOfTwo<true>;
-pub type NonNativePowerOfTwo = PowerOfTwo<false>;
+pub type ForeignPowerOfTwo = PowerOfTwo<false>;
 
 #[derive(Clone, Copy, Debug)]
 pub struct PowerOfTwo<const NATIVE: bool> {
@@ -201,7 +201,7 @@ impl<const NATIVE: bool> From<PowerOfTwo<NATIVE>> for Modulus {
                 mask: value.mask,
             })
         } else {
-            Self::NonNativePowerOfTwo(PowerOfTwo {
+            Self::ForeignPowerOfTwo(PowerOfTwo {
                 bits: value.bits,
                 mask: value.mask,
             })
@@ -218,7 +218,7 @@ impl<const NATIVE: bool> TryFrom<Modulus> for PowerOfTwo<NATIVE> {
                 bits: value.bits,
                 mask: value.mask,
             }),
-            Modulus::NonNativePowerOfTwo(value) if !NATIVE => Ok(PowerOfTwo {
+            Modulus::ForeignPowerOfTwo(value) if !NATIVE => Ok(PowerOfTwo {
                 bits: value.bits,
                 mask: value.mask,
             }),

--- a/math/src/ring.rs
+++ b/math/src/ring.rs
@@ -13,8 +13,8 @@ pub(crate) mod prime;
 
 use itertools::izip;
 pub use power_of_two::{
-    noisy::{NoisyNativeRing, NoisyNonNativePowerOfTwoRing},
-    precise::{NativeRing, NonNativePowerOfTwoRing},
+    noisy::{NoisyNativeRing, NoisyForeignPowerOfTwoRing},
+    precise::{NativeRing, ForeignPowerOfTwoRing},
 };
 pub use prime::{noisy::NoisyPrimeRing, precise::PrimeRing};
 

--- a/math/src/ring.rs
+++ b/math/src/ring.rs
@@ -13,8 +13,8 @@ pub(crate) mod prime;
 
 use itertools::izip;
 pub use power_of_two::{
-    noisy::{NoisyNativeRing, NoisyForeignPowerOfTwoRing},
-    precise::{NativeRing, ForeignPowerOfTwoRing},
+    noisy::{NoisyForeignPowerOfTwoRing, NoisyNativeRing},
+    precise::{ForeignPowerOfTwoRing, NativeRing},
 };
 pub use prime::{noisy::NoisyPrimeRing, precise::PrimeRing};
 

--- a/math/src/ring/power_of_two/noisy.rs
+++ b/math/src/ring/power_of_two/noisy.rs
@@ -10,7 +10,7 @@ pub type NoisyPowerOfTwoRing<const NATIVE: bool> = power_of_two::PowerOfTwoRing<
 
 pub type NoisyNativeRing = NoisyPowerOfTwoRing<true>;
 
-pub type NoisyNonNativePowerOfTwoRing = NoisyPowerOfTwoRing<false>;
+pub type NoisyForeignPowerOfTwoRing = NoisyPowerOfTwoRing<false>;
 
 impl<const NATIVE: bool> RingOps for NoisyPowerOfTwoRing<NATIVE> {
     type Eval = Complex64;
@@ -101,10 +101,10 @@ impl<const NATIVE: bool> RingOps for NoisyPowerOfTwoRing<NATIVE> {
 mod test {
     use crate::{
         distribution::Sampler,
-        modulus::{Modulus, NonNativePowerOfTwo},
+        modulus::{Modulus, ForeignPowerOfTwo},
         poly::ffnt::test::{poly_mul_prec_loss, round_trip_prec_loss},
         ring::{
-            power_of_two::noisy::{NoisyNativeRing, NoisyNonNativePowerOfTwoRing},
+            power_of_two::noisy::{NoisyNativeRing, NoisyForeignPowerOfTwoRing},
             test::{test_poly_mul, test_round_trip},
             RingOps,
         },
@@ -113,13 +113,13 @@ mod test {
     use rand::{distributions::Uniform, thread_rng};
 
     #[test]
-    fn non_native_round_trip() {
+    fn foreign_round_trip() {
         let mut rng = thread_rng();
         for log_ring_size in 0..10 {
             for log_q in 50..56 {
                 let prec_loss = round_trip_prec_loss(log_ring_size, log_q);
-                let ring: NoisyNonNativePowerOfTwoRing =
-                    RingOps::new(NonNativePowerOfTwo::new(log_q).into(), 1 << log_ring_size);
+                let ring: NoisyForeignPowerOfTwoRing =
+                    RingOps::new(ForeignPowerOfTwo::new(log_q).into(), 1 << log_ring_size);
                 for _ in 0..100 {
                     let a = ring.sample_uniform_vec(ring.ring_size(), &mut rng);
                     test_round_trip(&ring, &a, |a, b| assert_precision!(a, b, prec_loss));
@@ -142,12 +142,12 @@ mod test {
     }
 
     #[test]
-    fn non_native_poly_mul() {
+    fn foreign_poly_mul() {
         let mut rng = thread_rng();
         for log_ring_size in 0..10 {
             for log_q in 50..54 {
-                let ring: NoisyNonNativePowerOfTwoRing =
-                    RingOps::new(NonNativePowerOfTwo::new(log_q).into(), 1 << log_ring_size);
+                let ring: NoisyForeignPowerOfTwoRing =
+                    RingOps::new(ForeignPowerOfTwo::new(log_q).into(), 1 << log_ring_size);
                 for log_b in 12..16 {
                     let prec_loss = poly_mul_prec_loss(log_ring_size, log_q, log_b);
                     let uniform_b = Uniform::new(0, 1u64 << log_b);

--- a/math/src/ring/power_of_two/noisy.rs
+++ b/math/src/ring/power_of_two/noisy.rs
@@ -101,10 +101,10 @@ impl<const NATIVE: bool> RingOps for NoisyPowerOfTwoRing<NATIVE> {
 mod test {
     use crate::{
         distribution::Sampler,
-        modulus::{Modulus, ForeignPowerOfTwo},
+        modulus::{ForeignPowerOfTwo, Modulus},
         poly::ffnt::test::{poly_mul_prec_loss, round_trip_prec_loss},
         ring::{
-            power_of_two::noisy::{NoisyNativeRing, NoisyForeignPowerOfTwoRing},
+            power_of_two::noisy::{NoisyForeignPowerOfTwoRing, NoisyNativeRing},
             test::{test_poly_mul, test_round_trip},
             RingOps,
         },

--- a/math/src/ring/power_of_two/precise.rs
+++ b/math/src/ring/power_of_two/precise.rs
@@ -11,7 +11,7 @@ pub type PowerOfTwoRing<const NATIVE: bool> = power_of_two::PowerOfTwoRing<usize
 
 pub type NativeRing = PowerOfTwoRing<true>;
 
-pub type NonNativePowerOfTwoRing = PowerOfTwoRing<false>;
+pub type ForeignPowerOfTwoRing = PowerOfTwoRing<false>;
 
 impl<const NATIVE: bool> RingOps for PowerOfTwoRing<NATIVE> {
     type Eval = Self::Elem;
@@ -94,9 +94,9 @@ impl<const NATIVE: bool> RingOps for PowerOfTwoRing<NATIVE> {
 mod test {
     use crate::{
         distribution::Sampler,
-        modulus::{Modulus, NonNativePowerOfTwo},
+        modulus::{ForeignPowerOfTwo, Modulus},
         ring::{
-            power_of_two::precise::{NativeRing, NonNativePowerOfTwoRing},
+            power_of_two::precise::{ForeignPowerOfTwoRing, NativeRing},
             test::{test_poly_mul, test_round_trip},
             RingOps,
         },
@@ -104,12 +104,12 @@ mod test {
     use rand::thread_rng;
 
     #[test]
-    fn non_native_round_trip() {
+    fn foreign_round_trip() {
         let mut rng = thread_rng();
         for log_ring_size in 0..10 {
             for log_q in 50..56 {
-                let ring: NonNativePowerOfTwoRing =
-                    RingOps::new(NonNativePowerOfTwo::new(log_q).into(), 1 << log_ring_size);
+                let ring: ForeignPowerOfTwoRing =
+                    RingOps::new(ForeignPowerOfTwo::new(log_q).into(), 1 << log_ring_size);
                 let a = ring.sample_uniform_vec(ring.ring_size(), &mut rng);
                 test_round_trip(&ring, &a, |a, b| assert_eq!(a, b));
             }
@@ -127,12 +127,12 @@ mod test {
     }
 
     #[test]
-    fn non_native_poly_mul() {
+    fn foreign_poly_mul() {
         let mut rng = thread_rng();
         for log_ring_size in 0..10 {
             for log_q in 50..54 {
-                let ring: NonNativePowerOfTwoRing =
-                    RingOps::new(NonNativePowerOfTwo::new(log_q).into(), 1 << log_ring_size);
+                let ring: ForeignPowerOfTwoRing =
+                    RingOps::new(ForeignPowerOfTwo::new(log_q).into(), 1 << log_ring_size);
                 let a = ring.sample_uniform_vec(ring.ring_size(), &mut rng);
                 let b = ring.sample_uniform_vec(ring.ring_size(), &mut rng);
                 test_poly_mul(&ring, &a, &b, |a, b| assert_eq!(a, b));


### PR DESCRIPTION
- The term "Non-Native" use two words to describe what it is not.
- The term "Foreign" is an actual word used in paper https://eprint.iacr.org/2024/265.pdf