### PR TITLE
derive debug trait for FhewBoolEvaluator

### DIFF
--- a/evaluator/src/boolean/evaluator/fhew.rs
+++ b/evaluator/src/boolean/evaluator/fhew.rs
@@ -161,6 +161,7 @@ fn decode<R: RingOps>(ring: &R, pt: R::Elem) -> bool {
     m == 1
 }
 
+#[derive(Debug)]
 pub struct FhewBoolEvaluator<R: RingOps, M: ModulusOps> {
     ring: R,
     mod_ks: M,


### PR DESCRIPTION
This PR adds the Debug trait to `FhewBoolEvaluator`

However, I'm not sure if I'm doing the right way.

The need for the debug trait is reasoned as follows:

1. The server has to deserialize encrypted bit ciphertext for the computation.
2. We wrap the deserialized ciphertext with `FheBool`, because it has the `BitAnd`, `BitOr`, and `BitXor` implemented.
3. So my deserialization method have the output signature `Vec<FheBool<FhewBoolEvaluator<R, M>>>`
4. This comes with a problem if I want to `unwrap` the vector to fit a slice. Because unwrap requires a `Debug` trait for `FhewBoolEvaluator`


https://github.com/ChihChengLiang/haunted/pull/5/files